### PR TITLE
Changed 'usr' to 'urn'

### DIFF
--- a/service-specification.md
+++ b/service-specification.md
@@ -316,14 +316,14 @@ assuming there are two terms included in it is the following:
 
 \vspace*{-0.9cm}
 ```{.jql caption="MSR query format example"}
-instanceId:"usr:mrn:mcp:msr:int:specification:test" AND version=0.0.1
+instanceId:"urn:mrn:mcp:msr:int:specification:test" AND version=0.0.1
 ```
 
 If the *instanceId* is the default field, then field indicator is not required:
 
 \vspace*{-0.9cm}
 ```{.jql caption="MSR query format example with default field"}
-"usr:mrn:mcp:msr:int:specification:test" AND version=0.0.1
+"urn:mrn:mcp:msr:int:specification:test" AND version=0.0.1
 ```
 
 Wildcard searches should also be supported. 


### PR DESCRIPTION
I am not sure if it was on purpose that 'usr' was used, but I guess that it was probably supposed to be 'urn' instead?